### PR TITLE
detect more xml tags.

### DIFF
--- a/is-html.js
+++ b/is-html.js
@@ -14,7 +14,7 @@
 	}
 
 	function isHtml(str) {
-		if (/\s?<!doctype html>|(<html[^>]*>|<body[^>]*>|<x-[^>]+>)+/i.test(str)) {
+		if (/\s?<!doctype html>|(<html\b[^>]*>|<body\b[^>]*>|<x-[^>]+>)+/i.test(str)) {
 			return true;
 		}
 

--- a/test.js
+++ b/test.js
@@ -11,7 +11,9 @@ it('should detect HTML if it has doctype', function () {
 it('should detect HTML if it has <html>, <body> or <x-*>', function () {
 	assert(isHtml('<html>'));
 	assert(isHtml('<html></html>'));
+	assert(isHtml('<html lang="en"></html>'));
 	assert(isHtml('<html><body></html>'));
+	assert(isHtml('<html><body class="no-js"></html>'));
 	assert(isHtml('<x-unicorn>'));
 });
 
@@ -23,4 +25,6 @@ it('should detect HTML if it contains any of the standard HTML tags', function (
 it('should not match XML', function () {
 	assert(!isHtml('<cake>foo</cake>'));
 	assert(!isHtml('<any>rocks</any>'));
+	assert(!isHtml('<htmly>not</htmly>'));
+	assert(!isHtml('<bodyx>not</bodyx>'));
 });


### PR DESCRIPTION
i found, the `isHtml()` function, can not recognize tags like `<any>` or
`<angular>` as invalid HTML tags, cause they hit the regexp `/<a[^>]*>/`
and here is the fix.

and i also point the `npm test` command to local mocha, in case of
`mocha` was not installed globally.
