### PR TITLE
Precompile regexes for better performance

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
 'use strict';
 var htmlTags = require('html-tags');
 
+var basic = /\s?<!doctype html>|(<html\b[^>]*>|<body\b[^>]*>|<x-[^>]+>)+/i,
+	full = new RegExp(htmlTags.map(function (el) {
+			return '<' + el + '\\b[^>]*>';
+		}).join('|'), 'i');
+
 module.exports = function (str) {
-	if (/\s?<!doctype html>|(<html\b[^>]*>|<body\b[^>]*>|<x-[^>]+>)+/i.test(str)) {
+	if (basic.test(str)) {
 		return true;
 	}
 
-	var re = new RegExp(htmlTags.map(function (el) {
-		return '<' + el + '\\b[^>]*>';
-	}).join('|'), 'i');
-
-	return re.test(str);
+	 return full.test(str);
 };


### PR DESCRIPTION
Currently, the regexes are compiled on every call to is-html.  This is unnecessary; by precompiling the regexes once, we [realize a **100x** performance increase](https://jsperf.com/is-html-regexes).